### PR TITLE
Use Solidity v0.8.4+ so we can also use custom errors.

### DIFF
--- a/contracts/LlamaPayFactory.sol
+++ b/contracts/LlamaPayFactory.sol
@@ -5,6 +5,8 @@ import "hardhat/console.sol";
 import "@openzeppelin/contracts/access/Ownable.sol";
 import "./LlamaPay.sol";
 
+error AlreadyExists();
+
 contract LlamaPayFactory is Ownable {
     mapping(address => address) public payContracts;
     mapping(uint => address) public payContractsArray;
@@ -13,7 +15,8 @@ contract LlamaPayFactory is Ownable {
     event LlamaPayCreated(address token, address llamaPay);
 
     function createPayContract(address _token) external returns (address newContract) {
-        require(payContracts[_token] == address(0), "already exists");
+        // require(payContracts[_token] == address(0), "already exists");
+        if (payContracts[_token] != address(0)) revert AlreadyExists();
         newContract = address(new LlamaPay(_token, address(this)));
         payContracts[_token] = newContract;
         payContractsArray[payContractsArrayLength] = newContract;

--- a/contracts/LlamaPayFactory.sol
+++ b/contracts/LlamaPayFactory.sol
@@ -1,5 +1,5 @@
 //SPDX-License-Identifier: None
-pragma solidity ^0.8.0;
+pragma solidity ^0.8.4;
 
 import "hardhat/console.sol";
 import "@openzeppelin/contracts/access/Ownable.sol";

--- a/test/factory.ts
+++ b/test/factory.ts
@@ -38,7 +38,7 @@ describe("Factory", function () {
     expect(await token.balanceOf(llamaPay.address)).to.equal(amount);
     await expect(
       llamaPay.connect(attacker).emergencyRug(owner.address, amount)
-    ).to.be.revertedWith("not owner");
+    ).to.be.revertedWith("NotTheOwner()");
     await llamaPay.connect(owner).emergencyRug(owner.address, amount)
     expect(await token.balanceOf(llamaPay.address)).to.equal("0");
   })

--- a/test/llamaPay.ts
+++ b/test/llamaPay.ts
@@ -72,7 +72,7 @@ describe("LlamaPay", function () {
     it("can't withdraw on a cancelled stream", async ()=>{
         const {payer, payee, llamaPay, perSec} = await setupStream(5e3);
         await llamaPay.cancelStream(payee.address, perSec)
-        await expect(llamaPay.withdraw(payer.address, payee.address, perSec)).to.be.revertedWith("stream doesn't exist");
+        await expect(llamaPay.withdraw(payer.address, payee.address, perSec)).to.be.revertedWith("StreamDoesntExist()");
     })
     it("withdrawPayer works and if withdraw is called after less than perSec funds are left in contract", async ()=>{
         const {payer, payee, llamaPay, token, perSec} = await setupStream(10e3);
@@ -160,16 +160,16 @@ describe("LlamaPay", function () {
         const {payee, llamaPay} = await basicSetup();
         const perSec = "100000000000"
         llamaPay.createStream(payee.address, perSec)
-        await expect(llamaPay.createStream(payee.address, perSec)).to.be.revertedWith("stream already exists");
+        await expect(llamaPay.createStream(payee.address, perSec)).to.be.revertedWith("StreamAlreadyExists()");
     })
     it("can't withdraw from stream twice")
     it("withdraw while in debt and only get part of the tokens, do it twice from multiple addresses")
     it("can't create stream with 0 payment", async ()=>{
         const {payee, llamaPay} = await basicSetup();
-        await expect(llamaPay.createStream(payee.address, "0")).to.be.revertedWith("amountPerSec can't be 0");
+        await expect(llamaPay.createStream(payee.address, "0")).to.be.revertedWith("AmountPerSecCannotBeZero()");
     })
     it("can't cancel non-existent stream", async ()=>{
         const {payee, llamaPay} = await basicSetup();
-        await expect(llamaPay.cancelStream(payee.address, "1")).to.be.revertedWith("stream doesn't exist");
+        await expect(llamaPay.cancelStream(payee.address, "1")).to.be.revertedWith("StreamDoesntExist()");
     })
 })


### PR DESCRIPTION
We can use this because custom errors are a more efficient and gas efficient alternative to require. Just requires Solidity v0.8.4+

[More information from Solidity Blog](https://blog.soliditylang.org/2021/04/21/custom-errors/)