### PR TITLE
Updates and Improvements

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,137 @@ bin
 #Hardhat files
 cache
 artifacts
+
+# Byte-compiled / optimized / DLL files
+__pycache__/
+*.py[cod]
+*$py.class
+
+# C extensions
+*.so
+
+# Distribution / packaging
+.Python
+build/
+develop-eggs/
+dist/
+downloads/
+eggs/
+.eggs/
+lib/
+lib64/
+parts/
+sdist/
+var/
+wheels/
+pip-wheel-metadata/
+share/python-wheels/
+*.egg-info/
+.installed.cfg
+*.egg
+MANIFEST
+
+# PyInstaller
+#  Usually these files are written by a python script from a template
+#  before PyInstaller builds the exe, so as to inject date/other infos into it.
+*.manifest
+*.spec
+
+# Installer logs
+pip-log.txt
+pip-delete-this-directory.txt
+
+# Unit test / coverage reports
+htmlcov/
+.tox/
+.nox/
+.coverage
+.coverage.*
+.cache
+nosetests.xml
+coverage.xml
+*.cover
+*.py,cover
+.hypothesis/
+.pytest_cache/
+
+# Translations
+*.mo
+*.pot
+
+# Django stuff:
+*.log
+local_settings.py
+db.sqlite3
+db.sqlite3-journal
+
+# Flask stuff:
+instance/
+.webassets-cache
+
+# Scrapy stuff:
+.scrapy
+
+# Sphinx documentation
+docs/_build/
+
+# PyBuilder
+target/
+
+# Jupyter Notebook
+.ipynb_checkpoints
+
+# IPython
+profile_default/
+ipython_config.py
+
+# pyenv
+.python-version
+
+# pipenv
+#   According to pypa/pipenv#598, it is recommended to include Pipfile.lock in version control.
+#   However, in case of collaboration, if having platform-specific dependencies or dependencies
+#   having no cross-platform support, pipenv may install dependencies that don't work, or not
+#   install all needed dependencies.
+#Pipfile.lock
+
+# PEP 582; used by e.g. github.com/David-OConnor/pyflow
+__pypackages__/
+
+# Celery stuff
+celerybeat-schedule
+celerybeat.pid
+
+# SageMath parsed files
+*.sage.py
+
+# Environments
+.env
+.venv
+env/
+venv/
+ENV/
+env.bak/
+venv.bak/
+
+# Spyder project settings
+.spyderproject
+.spyproject
+
+# Rope project settings
+.ropeproject
+
+# mkdocs documentation
+/site
+
+# mypy
+.mypy_cache/
+.dmypy.json
+dmypy.json
+
+# Pyre type checker
+.pyre/
+
+# eth-brownie
+.history
+reports/

--- a/brownie-config.yaml
+++ b/brownie-config.yaml
@@ -1,0 +1,7 @@
+compiler:
+  solc:
+    remappings:
+      - "@openzeppelin=OpenZeppelin/openzeppelin-contracts@4.5.0"
+
+dependencies:
+  - OpenZeppelin/openzeppelin-contracts@4.5.0

--- a/contracts/LlamaPay.sol
+++ b/contracts/LlamaPay.sol
@@ -4,7 +4,8 @@ pragma solidity ^0.8.0;
 import "@openzeppelin/contracts/token/ERC20/IERC20.sol";
 
 interface Factory {
-    function owner() external returns (address);
+    function owner() external view returns (address);
+    function parameter() external view returns (address);
 }
 
 interface IERC20WithDecimals {
@@ -34,10 +35,10 @@ contract LlamaPay {
     event StreamCreated(address indexed from, address indexed to, uint216 amountPerSec, bytes32 streamId);
     event StreamCancelled(address indexed from, address indexed to, uint216 amountPerSec, bytes32 streamId);
 
-    constructor(address _token){
-        token = IERC20(_token);
+    constructor(){
+        token = IERC20(Factory(msg.sender).parameter());
         factory = msg.sender;
-        uint8 tokenDecimals = IERC20WithDecimals(_token).decimals();
+        uint8 tokenDecimals = IERC20WithDecimals(address(token)).decimals();
         DECIMALS_DIVISOR = 10**(20 - tokenDecimals);
     }
 

--- a/contracts/LlamaPay.sol
+++ b/contracts/LlamaPay.sol
@@ -34,9 +34,9 @@ contract LlamaPay {
     event StreamCreated(address indexed from, address indexed to, uint216 amountPerSec, bytes32 streamId);
     event StreamCancelled(address indexed from, address indexed to, uint216 amountPerSec, bytes32 streamId);
 
-    constructor(address _token, address _factory){
+    constructor(address _token){
         token = IERC20(_token);
-        factory = _factory;
+        factory = msg.sender;
         uint8 tokenDecimals = IERC20WithDecimals(_token).decimals();
         DECIMALS_DIVISOR = 10**(20 - tokenDecimals);
     }

--- a/contracts/LlamaPay.sol
+++ b/contracts/LlamaPay.sol
@@ -2,7 +2,6 @@
 pragma solidity ^0.8.0;
 
 import "@openzeppelin/contracts/token/ERC20/IERC20.sol";
-import "hardhat/console.sol";
 
 interface Factory {
     function owner() external returns (address);

--- a/contracts/LlamaPayFactory.sol
+++ b/contracts/LlamaPayFactory.sol
@@ -1,7 +1,6 @@
 //SPDX-License-Identifier: None
 pragma solidity ^0.8.0;
 
-import "hardhat/console.sol";
 import "@openzeppelin/contracts/access/Ownable.sol";
 import "./LlamaPay.sol";
 

--- a/contracts/LlamaPayFactory.sol
+++ b/contracts/LlamaPayFactory.sol
@@ -6,9 +6,12 @@ import {LlamaPay} from "./LlamaPay.sol";
 
 contract LlamaPayFactory {
     address constant OG_LLAMA = 0xeF21F3909275245CCF813F89774945E1EdCeb6ED; // 0xngmi.eth
+    bytes32 constant INIT_CODEHASH = keccak256(type(LlamaPay).creationCode);
 
     address public owner;
     address public futureOwner;
+
+    address public parameter;
     uint256 public getLlamaPayContractCount;
     address[1000000000] public getLlamaPayContractByIndex; // 1 billion indices
 
@@ -29,8 +32,10 @@ contract LlamaPayFactory {
         @return llamaPayContract The address of the newly created Llama Pay contract
       */
     function createLlamaPayContract(address _token) external returns (address llamaPayContract) {
+        // set the parameter storage slot so the contract can query it
+        parameter = _token;
         // use CREATE2 so we can get a deterministic address based on the token
-        llamaPayContract = address(new LlamaPay{salt: bytes32(uint256(uint160(_token)))}(_token));
+        llamaPayContract = address(new LlamaPay{salt: bytes32(uint256(uint160(_token)))}());
         // CREATE2 can return address(0), add a check to verify this isn't the case
         // See: https://eips.ethereum.org/EIPS/eip-1014
         require(llamaPayContract != address(0));
@@ -55,11 +60,8 @@ contract LlamaPayFactory {
         predictedAddress = address(uint160(uint256(keccak256(abi.encodePacked(
             bytes1(0xff),
             address(this),
-            bytes32(uint256(uint160(_token))), // salt
-            keccak256(abi.encodePacked(
-                type(LlamaPay).creationCode,
-                _token
-            ))
+            bytes32(uint256(uint160(_token))),
+            INIT_CODEHASH
         )))));
         isDeployed = predictedAddress.code.length != 0;
     }


### PR DESCRIPTION
The current LlamaPay v1 contracts are golden. This is merely a series of improvements and iterations on the original design.

Most notably things being changed are:

- Using CREATE2 for deterministic deployment of LlamaPay instances: This has the benefit that duplicate contracts won't be made such as multiple USDC or DAI LlamaPay contracts. This is because we use the _token parameter as the salt.
- Using a static array instead of a mapping for the array of already deployed instances, this is a minor improvement but saves slightly on deployment costs since there is no need to do a hash to find the slot (storage slot = 3 + indexPosition)
- Remove the ownable OZ import (bloatware) - substituted for a commit/apply scheme (but can be changed to an inline transferOwnership function if preferred)

Things Planned todo:
- Use same method as EIP-1820 to make permissionless deployment possible [Nick's method](https://weka.medium.com/how-to-send-ether-to-11-440-people-187e332566b7)
  - Aids with multichain deployments on EVM chains
  - No worrying about maintaining a private key for future deployments
- Double/Triple check logic in the LlamaPay contracts
- Would be nice to add `balanceOf` or `vestedOf` methods so that one can see their entire vested balance across all streams


Note: I use eth-brownie and python for development, but prior to taking this PR out of draft status I'll be removing any python artifacts and reverting the repo to it's fully JS status :0