### PR TITLE
docs: update readme light of sablier v2

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,14 +38,14 @@ This has the issue that all integrations need to be mindful of that, so here are
 ## Features
 
 ### Gas costs
-Cost to create a stream:
+Cost to create a stream and fund a stream:
 | Protocol | Cost (gas) |
 |----------|-------------|
-| LlamaPay | 69,963
-| Sablier | 240,070
+| LlamaPay | 158,560
+| Sablier | 259,915
 | SuperFluid | 279,992
 
-So LlamaPay is 3.2x-3.7x cheaper than the competition!
+So LlamaPay is ~1.7x cheaper than the competition!
 
 ### No requirement on depositing all money needed for the stream
 Sablier requires you to pick a duration for each stream and deposit all the money needed for the entirety of the stream at the start. This doesn't map well to salaries, since length is indeterminate.
@@ -61,7 +61,6 @@ They can just set a CEX address and have someone else trigger withdrawals or tri
 After our public release, llamapay will be available on all EVM chains and all the contracts will share the same address across chains.
 
 ### No big precision errors
-Sablier uses the same units as the underlying token when handling math for the stream. This means that for tokens that have a low number for decimals(), such as USDC, this causes precision errors. For example: if you stream 1000 USDC to an address, you'll instead end up streaming 997 USDC instead due to these errors.
 
 LlamaPay operates internally with 20 decimals, which keep precision errors to a minimum.
 


### PR DESCRIPTION
Two changes:

- [x] Remove the note about the precision error in Sablier; this is no longer the case in V2, see our updated function [`_calculateStreamedAmount`](https://github.com/sablier-labs/v2-core/blob/v1.0.2/src/SablierV2LockupLinear.sol#L295-L337)
- [x] I updated the gas cost table with a more realistic figure. It is misleading to say that creating a LlamaPay stream costs only 70k gas, because that's only the cost of creating an empty, unfunded stream, which is useless. A useful LlamaPay stream has to be funded, and that costs ~158,560 based on my calculations: [72,204](https://polygonscan.com/tx/0x221c4e4a6fd45473b7aaf1d9d4922aecb337a3044a108786dc37f1c6dc0da98c) and [86,356](https://polygonscan.com/tx/0x145733ea08468b88f5278c9b48e2a1d1a32dfe47037754778245da078ebec6dd)